### PR TITLE
Add error handling tests, postman requests & small fixes

### DIFF
--- a/library-management-system/src/main/java/com/deloittedigital/library/config/ApplicationConfiguration.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/config/ApplicationConfiguration.java
@@ -13,8 +13,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.stream.Collectors;
-
 
 @Configuration
 public class ApplicationConfiguration {
@@ -48,9 +46,6 @@ public class ApplicationConfiguration {
             d.setName(s.getName());
             d.setDescription(s.getDescription());
             d.setCreatedAt(s.getCreatedAt());
-            d.setBooks(s.getBooks().stream()
-                    .map(x -> modelMapper.map(x , Book.class))
-                    .collect(Collectors.toSet()));
             return d;
         };
 

--- a/library-management-system/src/main/java/com/deloittedigital/library/config/AuthorClientConfiguration.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/config/AuthorClientConfiguration.java
@@ -23,7 +23,7 @@ public class AuthorClientConfiguration {
     }
 
     public String getSpecific() {
-        return specific;
+        return base + specific;
     }
 
 }

--- a/library-management-system/src/main/java/com/deloittedigital/library/controller/BookController.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/controller/BookController.java
@@ -45,14 +45,6 @@ public class BookController {
                 .collect(Collectors.toList()));
     }
 
-    @GetMapping("/available")
-    public ResponseEntity<List<BookDTO>> getAllAvailableBooks() {
-        return ResponseEntity.ok(bookService.getAvailableBooks()
-                .stream()
-                .map(book -> modelMapper.map(book, BookDTO.class))
-                .collect(Collectors.toList()));
-    }
-
     @GetMapping("/byCategory/{categoryId}")
     public ResponseEntity<List<BookDTO>> getAllBooksByCategory(@PathVariable("categoryId") Long categoryId) {
         return ResponseEntity.ok(bookService.getAllBooksByCategory(categoryId)
@@ -63,10 +55,9 @@ public class BookController {
 
     @GetMapping("/{id}")
     public ResponseEntity<BookDTO> get(@PathVariable("id") Long id) {
-        throw  new BookNotFoundException();
-//        Book book =  bookService.get(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, BOOK_NOT_FOUND));
-//
-//        return ResponseEntity.ok(modelMapper.map(book, BookDTO.class));
+        Book book =  bookService.get(id).orElseThrow(BookNotFoundException::new);
+
+        return ResponseEntity.ok(modelMapper.map(book, BookDTO.class));
     }
 
     @GetMapping("/borrowedBy/{userId}")
@@ -87,7 +78,7 @@ public class BookController {
 
     @PutMapping("/{id}")
     public ResponseEntity<BookDTO> update(@PathVariable("id") Long id, @RequestBody @Valid BookDTO bookDTO){
-        Book foundBook = bookService.get(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, BOOK_NOT_FOUND));
+        Book foundBook = bookService.get(id).orElseThrow(BookNotFoundException::new);
 
         bookDTO.setId(foundBook.getId());
         Book updatedBook = bookService.update(modelMapper.map(bookDTO, Book.class), foundBook.getCategory());

--- a/library-management-system/src/main/java/com/deloittedigital/library/controller/CategoryController.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.deloittedigital.library.controller;
 
+import com.deloittedigital.library.exception.CategoryNotFoundException;
 import com.deloittedigital.library.model.domain.Category;
 import com.deloittedigital.library.model.dto.CategoryDTO;
 import com.deloittedigital.library.service.ICategoryService;
@@ -24,7 +25,7 @@ public class CategoryController {
     private final ModelMapper modelMapper = new ModelMapper();
 
     @GetMapping
-    public ResponseEntity<List<CategoryDTO>> getAll(@RequestParam("name") String name) {
+    public ResponseEntity<List<CategoryDTO>> getAll() {
         return ResponseEntity.ok(categoryService.getAll()
                 .stream()
                 .map(category -> modelMapper.map(category, CategoryDTO.class))
@@ -34,7 +35,7 @@ public class CategoryController {
     @GetMapping("/{id}")
     public ResponseEntity<CategoryDTO> get(@PathVariable("id") Long id) {
         Category category =  categoryService.get(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, CATEGORY_NOT_FOUND));
+                .orElseThrow(CategoryNotFoundException::new);
 
         return ResponseEntity.ok(modelMapper.map(category, CategoryDTO.class));
     }
@@ -50,7 +51,7 @@ public class CategoryController {
     @PutMapping("/{id}")
     public ResponseEntity<CategoryDTO> update(@PathVariable("id") Long id, @RequestBody CategoryDTO categoryDTO) {
         Category foundCategory = categoryService.get(id)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, CATEGORY_NOT_FOUND));
+                .orElseThrow(CategoryNotFoundException::new);
 
         categoryDTO.setId(foundCategory.getId());
         Category updatedCategory = categoryService.update(modelMapper.map(categoryDTO, Category.class));

--- a/library-management-system/src/main/java/com/deloittedigital/library/model/dto/CategoryDTO.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/model/dto/CategoryDTO.java
@@ -2,8 +2,6 @@ package com.deloittedigital.library.model.dto;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
-import java.util.HashSet;
-import java.util.Set;
 
 public class CategoryDTO {
 
@@ -15,8 +13,6 @@ public class CategoryDTO {
     private String description;
 
     private LocalDate createdAt;
-
-    private Set<BookDTO> books = new HashSet<>();
 
     public String getName() {
         return name;
@@ -48,13 +44,5 @@ public class CategoryDTO {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public Set<BookDTO> getBooks() {
-        return books;
-    }
-
-    public void setBooks(Set<BookDTO> books) {
-        this.books = books;
     }
 }

--- a/library-management-system/src/main/java/com/deloittedigital/library/service/IBookService.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/service/IBookService.java
@@ -15,6 +15,5 @@ public interface IBookService {
     Book update(Book book, Category category);
     void delete(Book book);
     List<Book> getAllBooksBorrowedByUser(Long userId);
-    List<Book> getAvailableBooks();
     List<Book> getAllBooksByCategory(Long categoryId);
 }

--- a/library-management-system/src/main/java/com/deloittedigital/library/service/local/LocalBookService.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/service/local/LocalBookService.java
@@ -2,33 +2,34 @@ package com.deloittedigital.library.service.local;
 
 import com.deloittedigital.library.exception.InvalidISBNException;
 import com.deloittedigital.library.model.domain.Book;
+import com.deloittedigital.library.model.domain.Borrow;
 import com.deloittedigital.library.model.domain.Category;
 import com.deloittedigital.library.model.dto.SortFieldDTO;
 import com.deloittedigital.library.service.IBookService;
 import com.deloittedigital.library.service.ICategoryService;
+import com.deloittedigital.library.service.IUserService;
 import org.apache.commons.validator.routines.ISBNValidator;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.deloittedigital.library.exception.Constants.CATEGORY_NOT_FOUND;
-import static com.deloittedigital.library.service.local.LocalCategoryService.categoryList;
 import static java.util.Objects.isNull;
 
 @Service
 public class LocalBookService implements IBookService {
     private final ICategoryService categoryService;
+    private final IUserService userService;
     private List<Book> bookList;
 
-    public LocalBookService(ICategoryService localCategoryService) {
+    public LocalBookService(ICategoryService localCategoryService, IUserService userService) {
         this.categoryService = localCategoryService;
+        this.userService = userService;
         this.bookList = initBookList();
     }
 
@@ -36,7 +37,12 @@ public class LocalBookService implements IBookService {
     private List<Book> initBookList() {
         List<Book> books = new ArrayList<>();
 
+        Borrow borrow1 = new Borrow();
+        borrow1.setId(1L);
+        borrow1.setUser(userService.get(1L).get());
+
         Book book1 = new Book();
+        book1.setId(1L);
         book1.setTitle("Murder on the Orient Express");
         book1.setAuthor("Agatha Christie");
         book1.setPublisher("Grove Press");
@@ -44,12 +50,19 @@ public class LocalBookService implements IBookService {
         book1.setPublishedDate(LocalDate.of(2015, 1, 1));
         book1.setPages(300);
         book1.setNrCopies(5);
+        book1.setAvailableCopies(3);
         book1.setBorrowDays(6);
         book1.setIsbn("9780008268879");
         book1.setCategory(categoryService.get(0L).get());
+        book1.setBorrows(Collections.singleton(borrow1));
         books.add(book1);
 
+        Borrow borrow2 = new Borrow();
+        borrow2.setId(2L);
+        borrow2.setUser(userService.get(2L).get());
+
         Book book2 = new Book();
+        book2.setId(2L);
         book2.setTitle("And Then There Were None");
         book2.setAuthor("Agatha Christie");
         book2.setPublisher("Harper");
@@ -57,12 +70,16 @@ public class LocalBookService implements IBookService {
         book2.setPublishedDate(LocalDate.of(2011, 6, 30));
         book2.setPages(240);
         book2.setNrCopies(4);
+        book2.setAvailableCopies(2);
         book2.setBorrowDays(5);
         book2.setIsbn("0062073486");
         book2.setCategory(categoryService.get(0L).get());
+        book2.setBorrows(Stream.of(borrow1, borrow2)
+                .collect(Collectors.toCollection(HashSet::new)));
         books.add(book2);
 
         Book book3 = new Book();
+        book3.setId(3L);
         book3.setTitle("Pride and Prejudice");
         book3.setAuthor("Jane Austen");
         book3.setPublisher("Wordsworth");
@@ -70,12 +87,14 @@ public class LocalBookService implements IBookService {
         book3.setPublishedDate(LocalDate.of(1992, 6, 16));
         book3.setPages(352);
         book3.setNrCopies(4);
+        book3.setAvailableCopies(4);
         book3.setBorrowDays(6);
         book3.setIsbn("9781853260001");
         book3.setCategory(categoryService.get(1L).get());
         books.add(book3);
 
         Book book4 = new Book();
+        book4.setId(4L);
         book4.setTitle("Anna Karenina");
         book4.setAuthor("Lev Tolstoi");
         book4.setPublisher("Polirom");
@@ -83,12 +102,14 @@ public class LocalBookService implements IBookService {
         book4.setPublishedDate(LocalDate.of(2016, 6, 12));
         book4.setPages(936);
         book4.setNrCopies(2);
+        book4.setAvailableCopies(0);
         book4.setBorrowDays(10);
         book4.setIsbn("9789734627943");
         book4.setCategory(categoryService.get(1L).get());
         books.add(book4);
 
         Book book5 = new Book();
+        book5.setId(5L);
         book5.setTitle("Bird Box: Orbeste");
         book5.setAuthor("Josh Malerman");
         book5.setPublisher("Corint");
@@ -96,10 +117,12 @@ public class LocalBookService implements IBookService {
         book5.setPublishedDate(LocalDate.of(2019, 9, 15));
         book5.setPages(352);
         book5.setNrCopies(4);
+        book5.setAvailableCopies(0);
         book5.setBorrowDays(5);
         book5.setIsbn("9786067935646");
-        book5.setCategory(categoryList.get(2));
+        book5.setCategory(categoryService.get(2L).get());
         books.add(book5);
+
         return books;
     }
 
@@ -187,6 +210,16 @@ public class LocalBookService implements IBookService {
         Book foundBook = bookList.stream().filter(b -> b.getId().equals(book.getId())).findFirst().get();
         int foundBookIndex = bookList.indexOf(foundBook);
 
+        foundBook.setTitle(book.getTitle());
+        foundBook.setAuthor(book.getAuthor());
+        foundBook.setPublisher(book.getPublisher());
+        foundBook.setLanguage(book.getLanguage());
+        foundBook.setPublishedDate(book.getPublishedDate());
+        foundBook.setPages(book.getPages());
+        foundBook.setNrCopies(book.getNrCopies());
+        foundBook.setAvailableCopies(book.getAvailableCopies());
+        foundBook.setBorrowDays(book.getBorrowDays());
+        foundBook.setIsbn(book.getIsbn());
         foundBook.setCategory(category);
 
         bookList.set(foundBookIndex, foundBook);
@@ -202,12 +235,6 @@ public class LocalBookService implements IBookService {
         return bookList.stream()
                 .filter(book -> book.getBorrows().stream()
                         .anyMatch(borrow -> borrow.getUser().getId().equals(userId)))
-                .collect(Collectors.toList());
-    }
-
-    public List<Book> getAvailableBooks() {
-        return bookList.stream()
-                .filter(book -> book.getAvailableCopies() > 0)
                 .collect(Collectors.toList());
     }
 

--- a/library-management-system/src/main/java/com/deloittedigital/library/service/local/LocalCategoryService.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/service/local/LocalCategoryService.java
@@ -2,7 +2,6 @@ package com.deloittedigital.library.service.local;
 
 import com.deloittedigital.library.model.domain.Category;
 import com.deloittedigital.library.service.ICategoryService;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -32,6 +31,10 @@ public class LocalCategoryService implements ICategoryService {
     public Category update(Category category) {
         Category foundCategory = categoryList.stream().filter(cat -> cat.getId().equals(category.getId())).findFirst().get();
         int foundCategoryIdx = categoryList.indexOf(foundCategory);
+
+        if (category.getCreatedAt() == null){
+            category.setCreatedAt(foundCategory.getCreatedAt());
+        }
         categoryList.set(foundCategoryIdx, category);
         return category;
     }
@@ -47,18 +50,21 @@ public class LocalCategoryService implements ICategoryService {
         thriller.setId(0L);
         thriller.setName("Thriller");
         thriller.setDescription("Thrillers are a genre of fiction in which tough, resourceful, but essentially ordinary heroes are pitted against villains determined to destroy them, their country, or the stability of the free world.");
+        thriller.setCreatedAt(LocalDate.of(2020, 1, 1));
         categories.add(thriller);
 
         Category romance = new Category();
         romance.setId(1L);
         romance.setName("Romance");
         romance.setDescription("A romance book is a genre fiction which places its primary focus on the relationship and romantic love between two people, and usually has an emotionally satisfying and optimistic ending.");
+        romance.setCreatedAt(LocalDate.of(2020, 3, 1));
         categories.add(romance);
 
         Category horror = new Category();
         horror.setId(2L);
         horror.setName("Horror");
         horror.setDescription("Meant to cause discomfort and fear for both the character and readers, horror writers often make use of supernatural and paranormal elements in morbid stories that are sometimes a little too realistic.");
+        horror.setCreatedAt(LocalDate.of(2021, 1, 1));
         categories.add(horror);
         return categories;
     }

--- a/library-management-system/src/main/java/com/deloittedigital/library/service/local/LocalUserService.java
+++ b/library-management-system/src/main/java/com/deloittedigital/library/service/local/LocalUserService.java
@@ -37,6 +37,7 @@ public class LocalUserService implements IUserService {
     private static List<User> initUsers() {
         List<User> users = new ArrayList<>();
         User user1 = new User();
+        user1.setId(1L);
         user1.setFirstName("Ioana");
         user1.setLastName("Trandafir");
         user1.setEmail("itrandafir@deloittece.com");
@@ -44,6 +45,7 @@ public class LocalUserService implements IUserService {
         user1.setMobilePhone("+40772305435");
         users.add(user1);
         User user2 = new User();
+        user2.setId(2L);
         user2.setFirstName("Alex");
         user2.setLastName("Petrescu");
         user2.setEmail("apetrescu@deloittece.com");

--- a/library-management-system/src/test/java/com/deloittedigital/library/controller/CategoryControllerTest.java
+++ b/library-management-system/src/test/java/com/deloittedigital/library/controller/CategoryControllerTest.java
@@ -1,16 +1,31 @@
 package com.deloittedigital.library.controller;
 
+import com.deloittedigital.library.model.domain.Category;
+import com.deloittedigital.library.model.dto.ApiError;
+import com.deloittedigital.library.model.dto.CategoryDTO;
 import com.deloittedigital.library.service.ICategoryService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import static com.deloittedigital.library.service.local.LocalCategoryService.initCategories;
+import java.util.Optional;
+
+import static com.deloittedigital.library.exception.ErrorType.CATEGORY_NOT_FOUND;
+import static com.deloittedigital.library.service.local.LocalCategoryService.categoryList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CategoryController.class)
@@ -22,13 +37,106 @@ class CategoryControllerTest {
     @MockBean
     ICategoryService iCategoryService;
 
-    @Test
-    void testCategoryList() throws Exception {
-        when(iCategoryService.getAll()).thenReturn(initCategories());
-        mockMvc.perform(get("/categories"))
-                .andExpect(status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.[*]").isNotEmpty());
+    private static ObjectMapper objectMapper;
+    private static ModelMapper modelMapper;
+
+    @BeforeAll
+    static void setUp() {
+        modelMapper = new ModelMapper();
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     }
 
+    @Test
+    void testCategoryList() throws Exception {
+        when(iCategoryService.getAll()).thenReturn(categoryList);
+        mockMvc.perform(get("/categories"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.[*]").isNotEmpty());
+    }
+
+    @Test
+    void testGetCategoryById_happyPath() throws Exception {
+        Category category = categoryList.get(0);
+        CategoryDTO expectedCategory = modelMapper.map(category, CategoryDTO.class);
+
+        when(iCategoryService.get(1L)).thenReturn(Optional.of(category));
+
+        mockMvc.perform(get("/categories/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedCategory)));
+
+    }
+
+    @Test
+    void testGetCategoryById_whenCategoryNotFound_throwsException() throws Exception {
+        ApiError expectedResponse = ApiError.builder()
+                .errorCode(CATEGORY_NOT_FOUND.getErrorCode())
+                .reason(CATEGORY_NOT_FOUND.getReason())
+                .build();
+        when(iCategoryService.get(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/categories/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+    }
+
+    @Test
+    void testUpdateCategory_happyPath() throws Exception {
+        Category category = categoryList.get(0);
+        CategoryDTO inputCategory = modelMapper.map(category, CategoryDTO.class);
+
+        Category updatedCategory = categoryList.get(1);
+        CategoryDTO expectedCategory = modelMapper.map(updatedCategory, CategoryDTO.class);
+
+        when(iCategoryService.get(1L)).thenReturn(Optional.of(category));
+        when(iCategoryService.update(any(Category.class))).thenReturn(updatedCategory);
+
+        mockMvc.perform(
+                put("/categories/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(inputCategory)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedCategory)));
+
+    }
+
+    @Test
+    void testUpdateCategory_whenCategoryNotFound_throwsException() throws Exception {
+        ApiError expectedResponse = ApiError.builder()
+                .errorCode(CATEGORY_NOT_FOUND.getErrorCode())
+                .reason(CATEGORY_NOT_FOUND.getReason())
+                .build();
+        when(iCategoryService.get(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(
+                put("/categories/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CategoryDTO())))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedResponse)));
+    }
+
+    @Test
+    void testDeleteCategory_happyPath() throws Exception {
+        Category category = categoryList.get(0);
+
+        when(iCategoryService.get(1L)).thenReturn(Optional.of(category));
+        doNothing().when(iCategoryService).delete(category);
+
+        mockMvc.perform(
+                delete("/categories/1"))
+                .andExpect(status().isNoContent());
+
+    }
+
+    @Test
+    void testDeleteCategory_whenCategoryNotFound_throwsException() throws Exception {
+        when(iCategoryService.get(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(delete("/categories/1"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/spring-bootcamp.postman_collection.json
+++ b/spring-bootcamp.postman_collection.json
@@ -1,0 +1,430 @@
+{
+	"info": {
+		"_postman_id": "44408e35-2d79-4775-b038-45a9dd925a89",
+		"name": "spring-bootcamp",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "author",
+			"item": [
+				{
+					"name": "Retrieve all authors",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:9999/author-app/author",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9999",
+							"path": [
+								"author-app",
+								"author"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Retrieve author by id",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:9999/author-app/author/1",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9999",
+							"path": [
+								"author-app",
+								"author",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "library-management-system",
+			"item": [
+				{
+					"name": "books",
+					"item": [
+						{
+							"name": "Retrieve all books",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/v1/books",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve books by author",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/v1/books?author=Agatha Christie",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books"
+									],
+									"query": [
+										{
+											"key": "author",
+											"value": "Agatha Christie"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve books by category",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/v1/books/byCategory/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books",
+										"byCategory",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve book by id",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/v1/books/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve books borrowed by user",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/v1/books/borrowedBy/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books",
+										"borrowedBy",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add a book",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"title\": \"The Notebook\",\r\n    \"author\": \"Nicholas Sparks\",\r\n    \"publisher\": \"Warner Books\",\r\n    \"language\": \"English\",\r\n    \"publishedDate\": \"01/10/1996\",\r\n    \"pages\": 214,\r\n    \"availableCopies\": 5,\r\n    \"nrCopies\": 10,\r\n    \"borrowDays\": 7,\r\n    \"isbn\": \"0-446-52080-2\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/v1/books/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books",
+										"1"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Edit a book",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"title\": \"The Notebook 2nd Edition\",\r\n    \"author\": \"Nicholas Sparks\",\r\n    \"publisher\": \"Warner Books\",\r\n    \"language\": \"English\",\r\n    \"publishedDate\": \"01/10/2000\",\r\n    \"pages\": 214,\r\n    \"availableCopies\": 5,\r\n    \"nrCopies\": 10,\r\n    \"borrowDays\": 7,\r\n    \"isbn\": \"0-446-52080-2\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/v1/books/6",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books",
+										"6"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete a book",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/v1/books/6",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"v1",
+										"books",
+										"6"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "categories",
+					"item": [
+						{
+							"name": "Retrieve all categories",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/categories",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Retrieve category by id",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/categories/2",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"categories",
+										"2"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add a category",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"id\": 3,\r\n    \"name\": \"Dystopian\",\r\n    \"description\": \"The dystopian genre imagines worlds or societies where life is extremely bad because of deprivation or oppression or terror, and human society is characterized by human misery, such as squalor, oppression, disease, overcrowding, environmental destruction, or war.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/categories",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Edit a category",
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"id\": 3,\r\n    \"name\": \"Dystopian Fiction\",\r\n    \"description\": \"The dystopian genre imagines worlds or societies where life is extremely bad because of deprivation or oppression or terror, and human society is characterized by human misery, such as squalor, oppression, disease, overcrowding, environmental destruction, or war.\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/categories/3",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"categories",
+										"3"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete a category",
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/categories/3",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"categories",
+										"3"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "users",
+					"item": [
+						{
+							"name": "Retrieve all users",
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:8080/users",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Add a user",
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "    {\r\n        \"id\": 3,\r\n        \"firstName\": \"Ion\",\r\n        \"lastName\": \"Ionescu\",\r\n        \"title\": \"Mr.\",\r\n        \"email\": \"iionescu@deloittece.com\",\r\n        \"mobilePhone\": \"+40772505555\"\r\n    }",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "http://localhost:8080/users",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "8080",
+									"path": [
+										"users"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This commit will add:
- `CategoryController` happy path & error scenarios tests
- collection of postman requests for ease of import/export in Postman and testing
- remove `/v1/books/available` endpoint, as we can get all the available books from `/v1/books` with `available=true` request param
- small fixes for failing tests and data inconsistencies (e.g. adding `id`'s for all the objects)